### PR TITLE
fixed test errors caused by styling and css selectors

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -95,9 +95,10 @@
 .comedian_container {
   background-color: wheat;
   display: flex;
-  flex-flow: wrap;
+  flex-direction: column;
   justify-content: center;
   color: black;
+  width: 100%;
 }
 .comic_header {
   width: 100%;
@@ -109,17 +110,22 @@
   display: flex;
   flex-flow: wrap;
   justify-content: center;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 .comedian_info_section {
-  width: 95%;
+  width: 100%;
 }
 .comic_name {
   font-size: 28px;
 }
-.specials_info_section {
-  width: 30%;
+.specials_container {
+  background-color: tan;
+  width: 100%;
+  display: flex;
+  flex-flow: wrap;
+  justify-content: space-around;
 }
+
 .new_form_page h1 {
   border: 2px solid black;
   background-color: wheat;

--- a/app/views/comedians/index.html.erb
+++ b/app/views/comedians/index.html.erb
@@ -18,24 +18,26 @@
 <div class="comedian_container">
   <h2 class="comic_header">Comedians</h2>
   <% @comedians.each do |comedian| %>
+  <section class="comedian<%= comedian.id %>">
     <div class="comedian_card_container">
-      <div class="comedian_info_section">
-        <section class="comedian<%= comedian.id %>">
-          <p class="comic_name"><%= comedian.name %></p>
-          <ul>
-            <li>Age: <%= comedian.age %></li>
-            <li>City: <%= comedian.city %></li>
-            <li>Number of specials: <%= comedian.specials.count %></li>
-          </ul>
-      </div>
+        <div class="comedian_info_section">
+            <p class="comic_name"><%= comedian.name %></p>
+            <ul>
+              <li>Age: <%= comedian.age %></li>
+              <li>City: <%= comedian.city %></li>
+              <li>Number of specials: <%= comedian.specials.count %></li>
+            </ul>
+        </div>
+      <section class="specials_container">
         <% comedian.specials.each do |special| %>
-        <div class="specials_info_section">
-          <p><img src="<%= special.image %>" class="special_image"/></p>
+          <div class="specials_info_section">
+            <p><img src="<%= special.image %>" class="special_image"/></p>
             <%= special.title %>
             <p>Length: <%= special.length %></p>
           </div>
         <% end %>
       </section>
     </div>
+  </section>
   <% end %>
 </div>

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -500,6 +500,6 @@
         null
       ]
     },
-    "timestamp": 1552770902
+    "timestamp": 1552857968
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.10.2/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" style="display:none;">
-      <div class="timestamp">Generated <abbr class="timeago" title="2019-03-16T15:15:02-06:00">2019-03-16T15:15:02-06:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2019-03-17T15:26:08-06:00">2019-03-17T15:26:08-06:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">

--- a/spec/features/comedians/index_spec.rb
+++ b/spec/features/comedians/index_spec.rb
@@ -76,7 +76,7 @@ describe "comedian index page" do
   it "shows a statistics area" do
     visit comedians_path
 
-    within ".statistics" do
+    within ".stats_container" do
       expect(page).to have_content("Average age: 34")
       expect(page).to have_content("Average special run length: 60")
       expect(page).to have_content("Cities:")


### PR DESCRIPTION
RSpec failed some tests due to manipulation of CSS selectors for styling.  Rearranged CSS selectors so that page layout remains correct but allows tests to pass.